### PR TITLE
Update bazel rules-go (#714)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz",
-    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.6/rules_go-0.16.6.tar.gz",
+    sha256 = "ade51a315fa17347e5c31201fdc55aa5ffb913377aa315dceb56ee9725e620ee",
 )
 
 http_archive(


### PR DESCRIPTION
Initial branch points to 76653f4302ca4eb3fb853540bf041f416849a2d9
This cherry picks https://github.com/kubernetes-sigs/cluster-api/pull/714 to get the latest rules-go to build with go 1.11.5
