### PR TITLE
UPSTREAM: <759>: openshift: config: Adjust to new version of kustomize.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ run: generate fmt vet ## Run against the configured Kubernetes cluster in ~/.kub
 
 .PHONY: deploy
 deploy: manifests ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-	kustomize build config/default | kubectl apply -f -
+	kustomize build config | kubectl apply -f -
 
 
 .PHONY: manifests

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -18,14 +18,14 @@ namePrefix: cluster-api-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../crds/machine_v1beta1_cluster.yaml
-- ../crds/machine_v1beta1_machine.yaml
-- ../crds/machine_v1beta1_machineclass.yaml
-- ../crds/machine_v1beta1_machinedeployment.yaml
-- ../crds/machine_v1beta1_machineset.yaml
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/manager.yaml
+- crds/machine_v1beta1_cluster.yaml
+- crds/machine_v1beta1_machine.yaml
+- crds/machine_v1beta1_machineclass.yaml
+- crds/machine_v1beta1_machinedeployment.yaml
+- crds/machine_v1beta1_machineset.yaml
+- rbac/rbac_role.yaml
+- rbac/rbac_role_binding.yaml
+- manager/manager.yaml
 
 patches:
-- manager_image_patch.yaml
+- default/manager_image_patch.yaml


### PR DESCRIPTION
The newest versions of kustomize block the use of relative paths, so
the "kustomize build config/default/" command now fails with the
following error message:

Error: rawResources failed to read Resources: Load from path ../crds/cluster_v1alpha1_cluster.yaml failed: security; file '../crds/cluster_v1alpha1_cluster.yaml' is not in or below '.../github.com/kubernetes-sigs/cluster-api/config/default'

This patch resolves this by moving kustomization.yaml down a
directory, so that all files it points to are in the same or
sub-directories of its location.

This was merged into upstream cluster-api via:
https://github.com/kubernetes-sigs/cluster-api/pull/759

Signed-off-by: Russell Bryant <rbryant@redhat.com>