### PR TITLE
UPSTREAM: <809>: openshift: Delete node on machine deletion

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -154,6 +154,14 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 			return reconcile.Result{}, err
 		}
 
+		if m.Status.NodeRef != nil {
+			klog.Infof("Deleting node %q for machine %q", m.Status.NodeRef.Name, m.Name)
+			if err := r.deleteNode(ctx, m.Status.NodeRef.Name); err != nil {
+				klog.Errorf("Error deleting node %q for machine %q", name, err)
+				return reconcile.Result{}, err
+			}
+		}
+
 		// Remove finalizer on successful deletion.
 		klog.Infof("machine object %v deletion successful, removing finalizer.", name)
 		m.ObjectMeta.Finalizers = util.Filter(m.ObjectMeta.Finalizers, machinev1.MachineFinalizer)
@@ -237,4 +245,17 @@ func (r *ReconcileMachine) isDeleteAllowed(machine *machinev1.Machine) bool {
 	// delete the machine this machine-controller is running on. Return false to not allow machine controller to delete its
 	// own machine.
 	return node.UID != machine.Status.NodeRef.UID
+}
+
+func (r *ReconcileMachine) deleteNode(ctx context.Context, name string) error {
+	var node corev1.Node
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: name}, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(2).Infof("Node %q not found", name)
+			return nil
+		}
+		klog.Errorf("Failed to get node %q: %v", name, err)
+		return err
+	}
+	return r.Client.Delete(ctx, &node)
 }


### PR DESCRIPTION
When deleting a machine this also deletes the backed node right away from the machine controller after the actuator succeed deleting the cloud instance, so no need to wait for the cloud nodelifecycle controller to garbage collect the orphan node
Needs:
https://github.com/openshift/cluster-api-provider-aws/pull/173
https://github.com/openshift/cluster-api-provider-aws/pull/177
See:
https://github.com/kubernetes-sigs/cluster-api/pull/809