### PR TITLE
UPSTREAM: <carry>: openshift: Allow to record machine update error

### DIFF
--- a/pkg/apis/machine/common/consts.go
+++ b/pkg/apis/machine/common/consts.go
@@ -51,6 +51,13 @@ const (
 	// Example: timeout trying to connect to GCE.
 	CreateMachineError MachineStatusError = "CreateError"
 
+	// There was an error while trying to update a Node that this
+	// Machine represents. This may indicate a transient problem that will be
+	// fixed automatically with time, such as a service outage,
+	//
+	// Example: error updating load balancers
+	UpdateMachineError MachineStatusError = "UpdateError"
+
 	// An error was encountered while trying to delete the Node that this
 	// Machine represents. This could be a transient or terminal error, but
 	// will only be observable if the provider's Machine controller has

--- a/pkg/errors/machines.go
+++ b/pkg/errors/machines.go
@@ -53,6 +53,13 @@ func CreateMachine(msg string, args ...interface{}) *MachineError {
 	}
 }
 
+func UpdateMachine(msg string, args ...interface{}) *MachineError {
+	return &MachineError{
+		Reason:  commonerrors.UpdateMachineError,
+		Message: fmt.Sprintf(msg, args...),
+	}
+}
+
 func DeleteMachine(msg string, args ...interface{}) *MachineError {
 	return &MachineError{
 		Reason:  commonerrors.DeleteMachineError,


### PR DESCRIPTION
**What this PR does / why we need it**:

In case a machine provider configuration is invalidated,
it's handful to record InvalidConfigurationMachineError event error.
So a human (or third party controller) can notice the fact without reading
machine controller logs and react accordingly.