### PR TITLE
build: Fix compatibility with new kustomize.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ run: generate fmt vet ## Run against the configured Kubernetes cluster in ~/.kub
 
 .PHONY: deploy
 deploy: manifests ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-	kustomize build config/default | kubectl apply -f -
+	kustomize build config/ | kubectl apply -f -
 
 
 .PHONY: manifests

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -18,14 +18,14 @@ namePrefix: cluster-api-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../crds/machine_v1beta1_cluster.yaml
-- ../crds/machine_v1beta1_machine.yaml
-- ../crds/machine_v1beta1_machineclass.yaml
-- ../crds/machine_v1beta1_machinedeployment.yaml
-- ../crds/machine_v1beta1_machineset.yaml
-- ../rbac/rbac_role.yaml
-- ../rbac/rbac_role_binding.yaml
-- ../manager/manager.yaml
+- crds/machine_v1beta1_cluster.yaml
+- crds/machine_v1beta1_machine.yaml
+- crds/machine_v1beta1_machineclass.yaml
+- crds/machine_v1beta1_machinedeployment.yaml
+- crds/machine_v1beta1_machineset.yaml
+- rbac/rbac_role.yaml
+- rbac/rbac_role_binding.yaml
+- manager/manager.yaml
 
 patches:
-- manager_image_patch.yaml
+- default/manager_image_patch.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
The newest versions of kustomize block the use of relative paths in
configuration.  This path fixes our config to work without error.

**Special notes for your reviewer**:
See https://github.com/metalkube/cluster-api-provider-baremetal/issues/5
and https://github.com/kubernetes-sigs/kustomize/issues/766

**Release note**:
```release-note
Fixes build with latest kustomize
```
