### PR TITLE
UPSTREAM: <carry>: openshift: validate machines with openshift specific constraints

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_types.go
+++ b/pkg/apis/machine/v1beta1/machine_types.go
@@ -17,9 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/cluster-api/pkg/apis/machine/common"
 )
@@ -30,6 +33,10 @@ const (
 
 	// MachineClusterLabelName is the label set on machines linked to a cluster.
 	MachineClusterLabelName = "cluster.k8s.io/cluster-name"
+
+	// MachineClusterIDLabel is the label that a machine must have to identify the
+	// cluster to which it belongs.
+	MachineClusterIDLabel = "machine.openshift.io/cluster-api-cluster"
 )
 
 // +genclient
@@ -230,6 +237,23 @@ type MachineVersionInfo struct {
 }
 
 /// [MachineVersionInfo]
+
+func (m *Machine) Validate() field.ErrorList {
+	errors := field.ErrorList{}
+
+	// validate spec.labels
+	fldPath := field.NewPath("spec")
+	if m.Labels[MachineClusterIDLabel] == "" {
+		errors = append(errors, field.Invalid(fldPath.Child("labels"), m.Labels, fmt.Sprintf("missing %v label.", MachineClusterIDLabel)))
+	}
+
+	// validate provider config is set
+	if m.Spec.ProviderSpec.Value == nil && m.Spec.ProviderSpec.ValueFrom == nil {
+		errors = append(errors, field.Invalid(fldPath.Child("spec").Child("providerspec"), m.Spec.ProviderSpec, "at least one of value or valueFrom fields must be set"))
+	}
+
+	return errors
+}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -127,6 +127,13 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	name := m.Name
 	klog.Infof("Reconciling Machine %q", name)
 
+	if errList := m.Validate(); len(errList) > 0 {
+		err := fmt.Errorf("%q machine validation failed: %v", m.Name, errList.ToAggregate().Error())
+		klog.Error(err)
+		r.eventRecorder.Eventf(m, corev1.EventTypeWarning, "FailedValidate", err.Error())
+		return reconcile.Result{}, err
+	}
+
 	// Cluster might be nil as some providers might not require a cluster object
 	// for machine management.
 	cluster, err := r.getCluster(ctx, m)

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -44,6 +44,16 @@ func TestReconcileRequest(t *testing.T) {
 			Finalizers: []string{v1beta1.MachineFinalizer, metav1.FinalizerDeleteDependents},
 			Labels: map[string]string{
 				v1beta1.MachineClusterLabelName: "testcluster",
+				v1beta1.MachineClusterIDLabel:   "testcluster",
+			},
+		},
+		Spec: v1beta1.MachineSpec{
+			ProviderSpec: v1beta1.ProviderSpec{
+				ValueFrom: &v1beta1.ProviderSpecSource{
+					MachineClass: &v1beta1.MachineClassRef{
+						Provider: "no-provider",
+					},
+				},
 			},
 		},
 	}
@@ -57,6 +67,16 @@ func TestReconcileRequest(t *testing.T) {
 			Finalizers: []string{v1beta1.MachineFinalizer, metav1.FinalizerDeleteDependents},
 			Labels: map[string]string{
 				v1beta1.MachineClusterLabelName: "testcluster",
+				v1beta1.MachineClusterIDLabel:   "testcluster",
+			},
+		},
+		Spec: v1beta1.MachineSpec{
+			ProviderSpec: v1beta1.ProviderSpec{
+				ValueFrom: &v1beta1.ProviderSpecSource{
+					MachineClass: &v1beta1.MachineClassRef{
+						Provider: "no-provider",
+					},
+				},
 			},
 		},
 	}
@@ -72,6 +92,16 @@ func TestReconcileRequest(t *testing.T) {
 			DeletionTimestamp: &time,
 			Labels: map[string]string{
 				v1alpha1.MachineClusterLabelName: "testcluster",
+				v1beta1.MachineClusterIDLabel:    "testcluster",
+			},
+		},
+		Spec: v1beta1.MachineSpec{
+			ProviderSpec: v1beta1.ProviderSpec{
+				ValueFrom: &v1beta1.ProviderSpecSource{
+					MachineClass: &v1beta1.MachineClassRef{
+						Provider: "no-provider",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Validate additional constrains that can't be properly specified in a CRD definition.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
