### PR TITLE
Upstream: <905>: openshift: Clarify log message for machine-controlle…

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -158,7 +158,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 			return reconcile.Result{}, nil
 		}
 		if !r.isDeleteAllowed(m) {
-			klog.Infof("Skipping reconciling of machine object %v", name)
+			klog.Infof("Deleting machine hosting this controller is not allowed. Skipping reconciliation of machine %q", name)
 			return reconcile.Result{}, nil
 		}
 		klog.Infof("reconciling machine object %v triggers delete.", name)


### PR DESCRIPTION
…r isDeleteAllowed

Users have noted that this log message is confusing and
does not lead to a clear path forward when deleting this
machine.

This commit makes it clear that the machine will not be
deleted.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1700931