### PR TITLE
UPSTREAM: <carry>: openshift: Ensure drain fail is requeued w/ delay

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -198,18 +198,13 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 		// deleted without a manual intervention.
 		if _, exists := m.ObjectMeta.Annotations[ExcludeNodeDrainingAnnotation]; !exists && m.Status.NodeRef != nil {
 			if err := r.drainNode(m); err != nil {
-				return reconcile.Result{}, err
+				return delayIfRequeueAfterError(err)
 			}
 		}
 
 		if err := r.actuator.Delete(ctx, cluster, m); err != nil {
-			if requeueErr, ok := err.(*controllerError.RequeueAfterError); ok {
-				klog.Infof("Actuator returned requeue-after error: %v", requeueErr)
-				return reconcile.Result{Requeue: true, RequeueAfter: requeueErr.RequeueAfter}, nil
-			}
-
 			klog.Errorf("Failed to delete machine %q: %v", name, err)
-			return reconcile.Result{}, err
+			return delayIfRequeueAfterError(err)
 		}
 
 		if m.Status.NodeRef != nil {
@@ -240,28 +235,17 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	if exist {
 		klog.Infof("Reconciling machine %q triggers idempotent update", name)
 		if err := r.actuator.Update(ctx, cluster, m); err != nil {
-			if requeueErr, ok := err.(*controllerError.RequeueAfterError); ok {
-				klog.Infof("Actuator returned requeue-after error: %v", requeueErr)
-				return reconcile.Result{Requeue: true, RequeueAfter: requeueErr.RequeueAfter}, nil
-			}
-
 			klog.Errorf(`Error updating machine "%s/%s": %v`, m.Namespace, name, err)
-			return reconcile.Result{}, err
+			return delayIfRequeueAfterError(err)
 		}
-
 		return reconcile.Result{}, nil
 	}
 
 	// Machine resource created. Machine does not yet exist.
 	klog.Infof("Reconciling machine object %v triggers idempotent create.", m.ObjectMeta.Name)
 	if err := r.actuator.Create(ctx, cluster, m); err != nil {
-		if requeueErr, ok := err.(*controllerError.RequeueAfterError); ok {
-			klog.Infof("Actuator returned requeue-after error: %v", requeueErr)
-			return reconcile.Result{Requeue: true, RequeueAfter: requeueErr.RequeueAfter}, nil
-		}
-
 		klog.Warningf("Failed to create machine %q: %v", name, err)
-		return reconcile.Result{}, err
+		return delayIfRequeueAfterError(err)
 	}
 
 	return reconcile.Result{}, nil
@@ -353,4 +337,13 @@ func (r *ReconcileMachine) deleteNode(ctx context.Context, name string) error {
 		return err
 	}
 	return r.Client.Delete(ctx, &node)
+}
+
+func delayIfRequeueAfterError(err error) (reconcile.Result, error) {
+	switch t := err.(type) {
+	case *controllerError.RequeueAfterError:
+		klog.Infof("Actuator returned requeue-after error: %v", err)
+		return reconcile.Result{Requeue: true, RequeueAfter: t.RequeueAfter}, nil
+	}
+	return reconcile.Result{}, err
 }

--- a/pkg/controller/machine/openshift_controller_test.go
+++ b/pkg/controller/machine/openshift_controller_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"errors"
+	controllerError "github.com/openshift/cluster-api/pkg/controller/error"
+	"testing"
+	"time"
+)
+
+func mockDrainNode(shouldDelay bool) error {
+	if shouldDelay {
+		return &controllerError.RequeueAfterError{RequeueAfter: 20 * time.Second}
+	}
+	return errors.New("other error")
+}
+
+func TestDelayIfRequeueAfterError(t *testing.T) {
+	tCases := []struct {
+		shouldDelay bool
+		expectedErr bool
+	}{
+		{
+			shouldDelay: true,
+			expectedErr: false,
+		},
+		{
+			shouldDelay: false,
+			expectedErr: true,
+		},
+	}
+	for i, tc := range tCases {
+		_, err := delayIfRequeueAfterError(mockDrainNode(tc.shouldDelay))
+		if err != nil && tc.expectedErr == false {
+			t.Fatalf("case %v received unexpected error type", i)
+		}
+	}
+}


### PR DESCRIPTION
Ensure we requeue with delay if drain fails.  Also add unit test
to validate.  Also ensures better code reuse for detecting
RequeueAfterError in various places.
