### PR TITLE
Add prevent deleting annotation

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_types.go
+++ b/pkg/apis/machine/v1beta1/machine_types.go
@@ -37,6 +37,10 @@ const (
 	// MachineClusterIDLabel is the label that a machine must have to identify the
 	// cluster to which it belongs.
 	MachineClusterIDLabel = "machine.openshift.io/cluster-api-cluster"
+
+	// PreserveInstanceAnnotation prevents a VM from being deleted by the
+	// machine-controller and will cause machine-controller to requeue.
+	PreserveInstanceAnnotation = "machine.openshift.io/preserve-instance"
 )
 
 // +genclient

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -313,6 +313,11 @@ func (r *ReconcileMachine) getCluster(ctx context.Context, machine *machinev1.Ma
 }
 
 func (r *ReconcileMachine) isDeleteAllowed(machine *machinev1.Machine) bool {
+	_, exists := machine.ObjectMeta.Annotations[machinev1.PreserveInstanceAnnotation]
+	if exists {
+		return false
+	}
+
 	if r.nodeName == "" || machine.Status.NodeRef == nil {
 		return true
 	}


### PR DESCRIPTION
Why we need this:

This commit adds the ability to prevent processing of deletion
of machine-objects when the annotation is present.  This
is particularly useful when an automated remediation mechanism
is implemented to serve as a way for administrators to
indicate they do not wish a particular machine to be
remediated for whatever reason.