### PR TITLE
Bug 1752088: Refactor isDeleteAllowed to remove most logic

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_types.go
+++ b/pkg/apis/machine/v1beta1/machine_types.go
@@ -37,6 +37,10 @@ const (
 	// MachineClusterIDLabel is the label that a machine must have to identify the
 	// cluster to which it belongs.
 	MachineClusterIDLabel = "machine.openshift.io/cluster-api-cluster"
+
+	// PreserveInstanceAnnotation prevents a VM from being deleted by the
+	// machine-controller and will cause machine-controller to requeue.
+	PreserveInstanceAnnotation = "machine.openshift.io/preserve-instance"
 )
 
 // +genclient

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -335,6 +335,11 @@ func (r *ReconcileMachine) getCluster(ctx context.Context, machine *machinev1.Ma
 }
 
 func (r *ReconcileMachine) isDeleteAllowed(machine *machinev1.Machine) bool {
+	_, exists := m.ObjectMeta.Annotations[machinev1.PreserveInstanceAnnotation]
+	if exists {
+		return false
+	}
+
 	if r.nodeName == "" || machine.Status.NodeRef == nil {
 		return true
 	}

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -335,29 +335,8 @@ func (r *ReconcileMachine) getCluster(ctx context.Context, machine *machinev1.Ma
 }
 
 func (r *ReconcileMachine) isDeleteAllowed(machine *machinev1.Machine) bool {
-	_, exists := m.ObjectMeta.Annotations[machinev1.PreserveInstanceAnnotation]
-	if exists {
-		return false
-	}
-
-	if r.nodeName == "" || machine.Status.NodeRef == nil {
-		return true
-	}
-
-	if machine.Status.NodeRef.Name != r.nodeName {
-		return true
-	}
-
-	node := &corev1.Node{}
-	if err := r.Client.Get(context.Background(), client.ObjectKey{Name: r.nodeName}, node); err != nil {
-		klog.Infof("Failed to determine if controller's node %q is associated with machine %q: %v", r.nodeName, machine.Name, err)
-		return true
-	}
-
-	// When the UID of the machine's node reference and this controller's actual node match then then the request is to
-	// delete the machine this machine-controller is running on. Return false to not allow machine controller to delete its
-	// own machine.
-	return node.UID != machine.Status.NodeRef.UID
+	_, exists := machine.ObjectMeta.Annotations[machinev1.PreserveInstanceAnnotation]
+	return !exists
 }
 
 func (r *ReconcileMachine) deleteNode(ctx context.Context, name string) error {


### PR DESCRIPTION
Currently, it is impossible to delete a machine from the
cluster if the machine-controller is running on said
machine.  This is mostly an artifact of upstream's
inability to smartly detect there is only one master
running to prevent deletion of the cluster, and
it is not desireable generally.

To support more automated remediation, we should not treat
any particular node specially.  Since we drain first,
we will not actually delete the underlying machine-object
until we are successfully started on a new host, preventing
the deletion of the final master.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1752088