### PR TITLE
Fix `make gazelle`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,8 +9,8 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "6e875ab4b6bf64a38c352887760f21203ab054676d9c1b274963907e0768740d",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.15.0/bazel-gazelle-0.15.0.tar.gz"],
+    sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")


### PR DESCRIPTION
```
ERROR: /home/vikas/go_work/src/sigs.k8s.io/cluster-api/WORKSPACE:24:1: file '@bazel_gazelle//:deps.bzl' does not contain symbol 'go_repository'
ERROR: /home/vikas/go_work/src/sigs.k8s.io/cluster-api/WORKSPACE:28:1: name 'go_repository' is not defined (did you mean 'git_repository'?)
ERROR: /home/vikas/go_work/src/sigs.k8s.io/cluster-api/WORKSPACE:34:1: name 'go_repository' is not defined (did you mean 'git_repository'?)
ERROR: Error evaluating WORKSPACE file
```
