### PR TITLE
UPSTREAM: <carry>: openshift: Read machine additional printer columns from annotations/labels

### DIFF
--- a/config/crds/machine_v1beta1_machine.yaml
+++ b/config/crds/machine_v1beta1_machine.yaml
@@ -6,6 +6,37 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: machines.machine.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.annotations['machine\.openshift\.io/instance-state']
+    description: State of instance
+    name: State
+    type: string
+  - JSONPath: .metadata.labels['machine\.openshift\.io/instance-type']
+    description: Type of instance
+    name: Type
+    type: string
+  - JSONPath: .metadata.labels['machine\.openshift\.io/region']
+    description: Region associated with machine
+    name: Region
+    type: string
+  - JSONPath: .metadata.labels['machine\.openshift\.io/zone']
+    description: Zone associated with machine
+    name: Zone
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Machine age
+    name: Age
+    type: date
+  - JSONPath: .status.nodeRef.name
+    description: Node associated with machine
+    name: Node
+    priority: 1
+    type: string
+  - JSONPath: .spec.providerID
+    description: Provider ID of machine created in cloud provider
+    name: ProviderID
+    priority: 1
+    type: string
   group: machine.openshift.io
   names:
     kind: Machine

--- a/config/crds/machine_v1beta1_machineset.yaml
+++ b/config/crds/machine_v1beta1_machineset.yaml
@@ -6,6 +6,27 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: machinesets.machine.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Desired Replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Current Replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Ready Replicas
+    name: Ready
+    type: integer
+  - JSONPath: .status.availableReplicas
+    description: Observed number of available replicas
+    name: Available
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Machineset age
+    name: Age
+    type: date
   group: machine.openshift.io
   names:
     kind: MachineSet

--- a/pkg/apis/machine/v1beta1/machine_types.go
+++ b/pkg/apis/machine/v1beta1/machine_types.go
@@ -46,6 +46,13 @@ const (
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".metadata.annotations['machine\.openshift\.io/instance-state']",description="State of instance"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/instance-type']",description="Type of instance"
+// +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/region']",description="Region associated with machine"
+// +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/zone']",description="Zone associated with machine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Machine age"
+// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.nodeRef.name",description="Node associated with machine",priority=1
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID of machine created in cloud provider",priority=1
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/machine/v1beta1/machineset_types.go
+++ b/pkg/apis/machine/v1beta1/machineset_types.go
@@ -35,6 +35,11 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
+// +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas",description="Desired Replicas"
+// +kubebuilder:printcolumn:name="Current",type="integer",JSONPath=".status.replicas",description="Current Replicas"
+// +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Ready Replicas"
+// +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.availableReplicas",description="Observed number of available replicas"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Machineset age"
 type MachineSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -49,6 +49,18 @@ const (
 
 	// ExcludeNodeDrainingAnnotation annotation explicitly skips node draining if set
 	ExcludeNodeDrainingAnnotation = "machine.openshift.io/exclude-node-draining"
+
+	// MachineRegionLabelName as annotation name for a machine region
+	MachineRegionLabelName = "machine.openshift.io/region"
+
+	// MachineAZLabelName as annotation name for a machine AZ
+	MachineAZLabelName = "machine.openshift.io/zone"
+
+	// MachineInstanceStateAnnotationName as annotation name for a machine instance state
+	MachineInstanceStateAnnotationName = "machine.openshift.io/instance-state"
+
+	// MachineInstanceTypeLabelName as annotation name for a machine instance type
+	MachineInstanceTypeLabelName = "machine.openshift.io/instance-type"
 )
 
 var DefaultActuator Actuator


### PR DESCRIPTION
Given we already support AWS, Azure and GCP instalations of OpenShift,
reading values from machine provider config is no longer an option.
Instead, let's read all needed values from machine annotations and labels.
Each actuator will be then responsible for making sure every machine
has all the annotations and labels that are needed to properly display
additional machine columns set.

Also, print provider ID and linked node only with '-o wide` option since they are secondary to displaying current state of a machine.

```yaml
$ oc get machines -n openshift-machine-api
NAME                                     STATE     TYPE              REGION      ZONE      AGE
jchaloup-x8pdp-master-0                  Running   Standard_D4s_v3   centralus   3         44m
jchaloup-x8pdp-master-1                  Running   Standard_D4s_v3   centralus   1         44m
jchaloup-x8pdp-master-2                  Running   Standard_D4s_v3   centralus   2         44m
jchaloup-x8pdp-worker-centralus1-b97mk   Running   Standard_D2s_v3   centralus   1         43m
jchaloup-x8pdp-worker-centralus2-8tz8d   Running   Standard_D2s_v3   centralus   2         43m
jchaloup-x8pdp-worker-centralus3-22zf5   Running   Standard_D2s_v3   centralus   3         43m
```

```yaml    
$ oc get machines -n openshift-machine-api -o wide
NAME                                     STATE     TYPE              REGION      ZONE      AGE       NODE                                     PROVIDERID
jchaloup-x8pdp-master-0                  Running   Standard_D4s_v3   centralus   3         47m       jchaloup-x8pdp-master-0                  azure:///subscriptions/6648228a-736c-4a4e-9a14-92a7e5190f4a/resourceGroups/jchaloup-x8pdp-rg/providers/Microsoft.Compute/virtualMachines/jchaloup-x8pdp-master-0
jchaloup-x8pdp-master-1                  Running   Standard_D4s_v3   centralus   1         47m       jchaloup-x8pdp-master-1                  azure:///subscriptions/6648228a-736c-4a4e-9a14-92a7e5190f4a/resourceGroups/jchaloup-x8pdp-rg/providers/Microsoft.Compute/virtualMachines/jchaloup-x8pdp-master-1
jchaloup-x8pdp-master-2                  Running   Standard_D4s_v3   centralus   2         47m       jchaloup-x8pdp-master-2                  azure:///subscriptions/6648228a-736c-4a4e-9a14-92a7e5190f4a/resourceGroups/jchaloup-x8pdp-rg/providers/Microsoft.Compute/virtualMachines/jchaloup-x8pdp-master-2
jchaloup-x8pdp-worker-centralus1-b97mk   Running   Standard_D2s_v3   centralus   1         46m       jchaloup-x8pdp-worker-centralus1-b97mk   azure:///subscriptions/6648228a-736c-4a4e-9a14-92a7e5190f4a/resourceGroups/jchaloup-x8pdp-rg/providers/Microsoft.Compute/virtualMachines/jchaloup-x8pdp-worker-centralus1-b97mk
jchaloup-x8pdp-worker-centralus2-8tz8d   Running   Standard_D2s_v3   centralus   2         46m       jchaloup-x8pdp-worker-centralus2-8tz8d   azure:///subscriptions/6648228a-736c-4a4e-9a14-92a7e5190f4a/resourceGroups/jchaloup-x8pdp-rg/providers/Microsoft.Compute/virtualMachines/jchaloup-x8pdp-worker-centralus2-8tz8d
jchaloup-x8pdp-worker-centralus3-22zf5   Running   Standard_D2s_v3   centralus   3         46m       jchaloup-x8pdp-worker-centralus3-22zf5   azure:///subscriptions/6648228a-736c-4a4e-9a14-92a7e5190f4a/resourceGroups/jchaloup-x8pdp-rg/providers/Microsoft.Compute/virtualMachines/jchaloup-x8pdp-worker-centralus3-22zf5
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
