### PR TITLE
UPSTREAM: <carry>: openshift: prevent replica updates when machineset is being deleted

### DIFF
--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -158,6 +158,12 @@ func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
+	// Ignore deleted MachineSets, this can happen when foregroundDeletion
+	// is enabled
+	if machineSet.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
 	result, err := r.reconcile(ctx, machineSet)
 	if err != nil {
 		klog.Errorf("Failed to reconcile MachineSet %q: %v", request.NamespacedName, err)


### PR DESCRIPTION
When a machineset is being deleted it is possible to get into an
endless loop where new machine's are constantly recreated as the
reconciliation logic doesn't take into account the machine set's
deletion timestamp.
