### PR TITLE
Add goimports into makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ manifests: ## Generate manifests e.g. CRD, RBAC etc.
 fmt: ## Run go fmt against code
 	go fmt ./pkg/... ./cmd/...
 
+.PHONY: goimports
+goimports: ## Go fmt your code
+	hack/goimports.sh .
+
 .PHONY: vet
 vet: ## Run go vet against code
 	go vet ./pkg/... ./cmd/...

--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REPO_NAME=$(basename "${PWD}")
+if [ "$IS_CONTAINER" != "" ]; then
+  for TARGET in "${@}"; do
+    find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec goimports -w {} \+
+  done
+  git diff --exit-code
+else
+  docker run -it --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
+    --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
+    openshift/origin-release:golang-1.12 \
+    ./hack/goimports.sh "${@}"
+fi

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -225,7 +225,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 			// after an instance was created. So only a small window is left when
 			// we can loose instances, e.g. right after request to create one
 			// was sent and before a list of node addresses was set.
-			if  len(m.Status.Addresses) > 0 || !isInvalidMachineConfigurationError(err) {
+			if len(m.Status.Addresses) > 0 || !isInvalidMachineConfigurationError(err) {
 				klog.Errorf("Failed to delete machine %q: %v", name, err)
 				return delayIfRequeueAfterError(err)
 			}

--- a/pkg/controller/machine/openshift_controller_test.go
+++ b/pkg/controller/machine/openshift_controller_test.go
@@ -18,9 +18,10 @@ package machine
 
 import (
 	"errors"
-	controllerError "github.com/openshift/cluster-api/pkg/controller/error"
 	"testing"
 	"time"
+
+	controllerError "github.com/openshift/cluster-api/pkg/controller/error"
 )
 
 func mockDrainNode(shouldDelay bool) error {

--- a/pkg/drain/drain_test.go
+++ b/pkg/drain/drain_test.go
@@ -30,10 +30,10 @@ import (
 
 	"github.com/go-log/log/capture"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
-	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
So the target can be run in CI and fail in case files are not properly goimport formated.