### PR TITLE
Disable metrics to avoid pod collisions

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,8 +50,10 @@ func main() {
 	// Create a new Cmd to provide shared dependencies and start components
 	syncPeriod := 10 * time.Minute
 	mgr, err := manager.New(cfg, manager.Options{
-		SyncPeriod: &syncPeriod,
-		Namespace:  *watchNamespace,
+		// Disable metrics serving
+		MetricsBindAddress: "0",
+		SyncPeriod:         &syncPeriod,
+		Namespace:          *watchNamespace,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Disable metrics to avoid pod collisions. This was enabled by default it https://github.com/kubernetes-sigs/controller-runtime/pull/510/files

See https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-api-provider-aws/261/pull-ci-openshift-cluster-api-provider-aws-master-e2e-aws-operator/727/artifacts/e2e-aws-operator/pods/openshift-machine-api_machine-api-controllers-6dd895f447-zglqq_nodelink-controller.log
