### PR TITLE
*: Consitently use DeletionTimestamp.IsZero

### DIFF
--- a/pkg/controller/machinedeployment/controller.go
+++ b/pkg/controller/machinedeployment/controller.go
@@ -176,7 +176,7 @@ func (r *ReconcileMachineDeployment) Reconcile(request reconcile.Request) (recon
 
 	// Ignore deleted MachineDeployments, this can happen when foregroundDeletion
 	// is enabled
-	if d.DeletionTimestamp != nil {
+	if !d.DeletionTimestamp.IsZero() {
 		return reconcile.Result{}, nil
 	}
 
@@ -260,7 +260,7 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1beta1.M
 		return reconcile.Result{}, err
 	}
 
-	if d.DeletionTimestamp != nil {
+	if !d.DeletionTimestamp.IsZero() {
 		return reconcile.Result{}, r.sync(d, msList, machineMap)
 	}
 

--- a/pkg/controller/machinedeployment/sync.go
+++ b/pkg/controller/machinedeployment/sync.go
@@ -426,7 +426,7 @@ func (r *ReconcileMachineDeployment) cleanupDeployment(oldMSs []*machinev1beta1.
 
 	// Avoid deleting machine set with deletion timestamp set
 	aliveFilter := func(ms *machinev1beta1.MachineSet) bool {
-		return ms != nil && ms.ObjectMeta.DeletionTimestamp == nil
+		return ms != nil && ms.ObjectMeta.DeletionTimestamp.IsZero()
 	}
 
 	cleanableMSes := dutil.FilterMachineSets(oldMSs, aliveFilter)
@@ -446,7 +446,7 @@ func (r *ReconcileMachineDeployment) cleanupDeployment(oldMSs []*machinev1beta1.
 		}
 
 		// Avoid delete machine set with non-zero replica counts
-		if ms.Status.Replicas != 0 || *(ms.Spec.Replicas) != 0 || ms.Generation > ms.Status.ObservedGeneration || ms.DeletionTimestamp != nil {
+		if ms.Status.Replicas != 0 || *(ms.Spec.Replicas) != 0 || ms.Generation > ms.Status.ObservedGeneration || !ms.DeletionTimestamp.IsZero() {
 			continue
 		}
 

--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -160,7 +160,7 @@ func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Re
 
 	// Ignore deleted MachineSets, this can happen when foregroundDeletion
 	// is enabled
-	if machineSet.DeletionTimestamp != nil {
+	if !machineSet.DeletionTimestamp.IsZero() {
 		return reconcile.Result{}, nil
 	}
 
@@ -422,7 +422,7 @@ func shouldExcludeMachine(machineSet *machinev1beta1.MachineSet, machine *machin
 		return true
 	}
 
-	if machine.ObjectMeta.DeletionTimestamp != nil {
+	if !machine.ObjectMeta.DeletionTimestamp.IsZero() {
 		return true
 	}
 

--- a/pkg/controller/machineset/delete_policy.go
+++ b/pkg/controller/machineset/delete_policy.go
@@ -45,7 +45,7 @@ type deletePriorityFunc func(machine *v1beta1.Machine) deletePriority
 
 // maps the creation timestamp onto the 0-100 priority range
 func oldestDeletePriority(machine *v1beta1.Machine) deletePriority {
-	if machine.DeletionTimestamp != nil && !machine.DeletionTimestamp.IsZero() {
+	if !machine.DeletionTimestamp.IsZero() {
 		return mustDelete
 	}
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {
@@ -65,7 +65,7 @@ func oldestDeletePriority(machine *v1beta1.Machine) deletePriority {
 }
 
 func newestDeletePriority(machine *v1beta1.Machine) deletePriority {
-	if machine.DeletionTimestamp != nil && !machine.DeletionTimestamp.IsZero() {
+	if !machine.DeletionTimestamp.IsZero() {
 		return mustDelete
 	}
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {
@@ -78,7 +78,7 @@ func newestDeletePriority(machine *v1beta1.Machine) deletePriority {
 }
 
 func randomDeletePolicy(machine *v1beta1.Machine) deletePriority {
-	if machine.DeletionTimestamp != nil && !machine.DeletionTimestamp.IsZero() {
+	if !machine.DeletionTimestamp.IsZero() {
 		return mustDelete
 	}
 	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {


### PR DESCRIPTION
[`IsZero`][1] includes a `nil` check.  Upstream PR is kubernetes-sigs/cluster-api#1798.

[1]: https://github.com/kubernetes/apimachinery/blob/641a75999153845d3b1dd839555903869beb7fec/pkg/apis/meta/v1/time.go#L60-L66