### PR TITLE
Update owners to reflect current team membership

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,8 @@
 
 approvers:
   - enxebre
-  - frobware
-  - ingvagabund
-  - bison
-  - paulfantom
-  - spangenberg
-  - vikaschoudhary16
+  - JoelSpeed
+  - elmiko
+  - lobziik
+  - alexander-demichev
+  - Fedosin


### PR DESCRIPTION
The owners file for this repository is very out of date. This repo is primarily owned by the Cluster Infrastructure team and as such, I have updated the owners file to match the current team membership, removing old team members who are no longer involved in the project
