### PR TITLE
Add "io.openshift.release.operator true" label to the Dockerfile

### DIFF
--- a/openshift/Dockerfile.openshift
+++ b/openshift/Dockerfile.openshift
@@ -14,3 +14,5 @@ LABEL description="Cluster API Controller Manager"
 COPY --from=builder /build/cluster-api-controller-manager /bin/cluster-api-controller-manager
 
 ENTRYPOINT [ "/bin/cluster-api-controller-manager" ]
+
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
To inform CI that the operator should be included in the release this PR adds the label to the Dockerfile.