### PR TITLE
UPSTREAM: <carry>: update dockerfile to go 1.17

### DIFF
--- a/openshift/Dockerfile.openshift
+++ b/openshift/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
 
 WORKDIR /build
 COPY . .


### PR DESCRIPTION
Update dockerfile to go 1.17, see: https://github.com/openshift/cluster-api/pull/150#issuecomment-982464445