### PR TITLE
NO-JIRA: e2e: add openstack testing script

### DIFF
--- a/openshift/e2e-openstack.sh
+++ b/openshift/e2e-openstack.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Running e2e-openstack.sh"
+
+unset GOFLAGS
+tmp="$(mktemp -d)"
+
+git clone --depth=1 "https://github.com/openshift/cluster-api-provider-openstack.git" "$tmp"
+
+exec make -C "$tmp/openshift" e2e


### PR DESCRIPTION
Similarly to what we do for the [other CAPI providers](https://github.com/openshift/cluster-api/blob/master/openshift/e2e-tests.sh), add openstack e2e testing script.
The only difference for Openstack E2Es, w.r.t. the other providers, is that they live in the provider repo, so we need to fetch that rather than the cluster-capi-operator one.