### PR TITLE
OCPBUGS-26111: add snyk file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,11 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - "vendor/**"
+    - "**/vendor/**"
+    - "test/**"
+  SNYK_CODE_WARNING:
+    - "cmd/clusterctl/client/cluster/template.go":
+      reason: "Target command is not exposed to users in OpenShift"


### PR DESCRIPTION
This file is used by the snyk security scanning tool, our configuration limits files which are not included or not exposed to users.