### PR TITLE
OCPBUGS-29519: openshift: add CustomNoUpgrade annotation value to feature-set

### DIFF
--- a/openshift/manifests/0000_30_cluster-api_04_cm.core-cluster-api.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_cm.core-cluster-api.yaml
@@ -8,7 +8,7 @@ data:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       creationTimestamp: null
       labels:
         cluster.x-k8s.io/provider: cluster-api
@@ -30,7 +30,7 @@ data:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/aggregate-to-manager: "true"
         cluster.x-k8s.io/provider: cluster-api
@@ -384,7 +384,7 @@ data:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: cluster-api
         clusterctl.cluster.x-k8s.io: ""
@@ -398,7 +398,7 @@ data:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: cluster-api
         clusterctl.cluster.x-k8s.io: ""
@@ -431,7 +431,7 @@ data:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       creationTimestamp: null
       labels:
         cluster.x-k8s.io/provider: cluster-api
@@ -458,7 +458,7 @@ data:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
       labels:
         cluster.x-k8s.io/provider: cluster-api
         clusterctl.cluster.x-k8s.io: ""
@@ -951,7 +951,7 @@ data:
         exclude.release.openshift.io/internal-openshift-hosted: "true"
         include.release.openshift.io/self-managed-high-availability: "true"
         include.release.openshift.io/single-node-developer: "true"
-        release.openshift.io/feature-set: TechPreviewNoUpgrade
+        release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
         service.beta.openshift.io/serving-cert-secret-name: capi-webhook-service-cert
       labels:
         cluster.x-k8s.io/provider: cluster-api
@@ -1003,7 +1003,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     provider.cluster.x-k8s.io/name: cluster-api

--- a/openshift/manifests/0000_30_cluster-api_04_crd.core-cluster-api.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_crd.core-cluster-api.yaml
@@ -6,7 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -1937,7 +1937,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -3338,7 +3338,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -4174,7 +4174,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -5024,7 +5024,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -6028,7 +6028,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -6904,7 +6904,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -7268,7 +7268,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -7483,7 +7483,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
   labels:
@@ -8063,7 +8063,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -8327,7 +8327,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -8535,7 +8535,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.18
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215095648-dca27d1f8c99
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215153220-d299b8b0a225
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -777,6 +777,8 @@ github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.m
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215095648-dca27d1f8c99 h1:xBz01PbsZ7HsttZ0PQVKTvUKLZByS5ktdJBr75kP1E4=
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215095648-dca27d1f8c99/go.mod h1:H95ZCEuVQWjL1E22PUrmvVvx4ULjeDLzSoJoxzgNTkc=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215153220-d299b8b0a225 h1:TVnzn4vcLgcR8jtt7SHpWWn/12W4yuEeWZaDldN/Lxw=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215153220-d299b8b0a225/go.mod h1:H95ZCEuVQWjL1E22PUrmvVvx4ULjeDLzSoJoxzgNTkc=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/providers.go
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/providers.go
@@ -109,7 +109,7 @@ func (p *provider) writeProviderComponentsConfigmap(fileName string, objs []unst
 	}
 
 	annotations := openshiftAnnotations
-	annotations[techPreviewAnnotation] = techPreviewAnnotationValue
+	annotations[featureSetAnnotationKey] = featureSetAnnotationValue
 
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -170,7 +170,7 @@ github.com/munnerz/goautoneg
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215095648-dca27d1f8c99
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215153220-d299b8b0a225
 ## explicit; go 1.18
 github.com/openshift/cluster-capi-operator/manifests-gen
 # github.com/pelletier/go-toml/v2 v2.0.8


### PR DESCRIPTION
Together with the TechPreviewNoUpgrade release.openshift.io/feature-set we also need to add CustomNoUpgrade as that is used in certain scenarios where CAPI provider ConfigMaps and CRDs are required.