### PR TITLE
OCPCLOUD-2517: openshift: promote core CAPI IPAM CRDs to GA

### DIFF
--- a/openshift/manifests/0000_30_cluster-api_04_crd.core-cluster-api.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_crd.core-cluster-api.yaml
@@ -8327,7 +8327,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api
@@ -8535,7 +8534,6 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade
   creationTimestamp: null
   labels:
     cluster.x-k8s.io/provider: cluster-api

--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -2,7 +2,7 @@ module tools
 
 go 1.18
 
-require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215153220-d299b8b0a225
+require github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240216070530-91b37162630f
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -779,6 +779,8 @@ github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215095648-d
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215095648-dca27d1f8c99/go.mod h1:H95ZCEuVQWjL1E22PUrmvVvx4ULjeDLzSoJoxzgNTkc=
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215153220-d299b8b0a225 h1:TVnzn4vcLgcR8jtt7SHpWWn/12W4yuEeWZaDldN/Lxw=
 github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215153220-d299b8b0a225/go.mod h1:H95ZCEuVQWjL1E22PUrmvVvx4ULjeDLzSoJoxzgNTkc=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240216070530-91b37162630f h1:s3109F/lyCzQtTjh9jclgnuldV8MUcZ81PBRxnGeD+k=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240216070530-91b37162630f/go.mod h1:H95ZCEuVQWjL1E22PUrmvVvx4ULjeDLzSoJoxzgNTkc=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -170,7 +170,7 @@ github.com/munnerz/goautoneg
 # github.com/opencontainers/go-digest v1.0.0
 ## explicit; go 1.13
 github.com/opencontainers/go-digest
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240215153220-d299b8b0a225
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20240216070530-91b37162630f
 ## explicit; go 1.18
 github.com/openshift/cluster-capi-operator/manifests-gen
 # github.com/pelletier/go-toml/v2 v2.0.8


### PR DESCRIPTION
Update the manifest by removing the:
release.openshift.io/feature-set: CustomNoUpgrade,TechPreviewNoUpgrade annotation to
Core CAPI IPAM CRDs as we want to promote it to GA.

TODO:
- [x] rebase on top of master once #196 merges
- [x] rerun dep bump once manifests-gen PR is merged