### PR TITLE
OCPBUGS-30586: fix e2e tests on release branches

### DIFF
--- a/openshift/e2e-openstack.sh
+++ b/openshift/e2e-openstack.sh
@@ -7,6 +7,15 @@ echo "Running e2e-openstack.sh"
 unset GOFLAGS
 tmp="$(mktemp -d)"
 
-git clone --depth=1 "https://github.com/openshift/cluster-api-provider-openstack.git" "$tmp"
+if [ "${PULL_BASE_REF}" == "master" ]; then
+  # the default branch for cluster-api-provider-openstack is main.
+  CAPO_BASE_REF="main"
+else
+  CAPO_BASE_REF=$PULL_BASE_REF
+fi
 
+echo "cloning github.com/openshift/cluster-api-provider-openstack at branch '$CAPO_BASE_REF'"
+git clone --single-branch --branch="$CAPO_BASE_REF" --depth=1 "https://github.com/openshift/cluster-api-provider-openstack.git" "$tmp"
+
+echo "running cluster-api-provider-openstack's: make -C 'openshift' e2e"
 exec make -C "$tmp/openshift" e2e

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -7,6 +7,15 @@ echo "Running e2e-tests.sh"
 unset GOFLAGS
 tmp="$(mktemp -d)"
 
-git clone --depth=1 "https://github.com/openshift/cluster-capi-operator.git" "$tmp"
+if [ "${PULL_BASE_REF}" == "master" ]; then
+  # the default branch for cluster-capi-operator is main.
+  CCAPIO_BASE_REF="main"
+else
+  CCAPIO_BASE_REF=$PULL_BASE_REF
+fi
 
+echo "cloning github.com/openshift/cluster-capi-operator at branch '$CCAPIO_BASE_REF'"
+git clone --single-branch --branch="$CCAPIO_BASE_REF" --depth=1 "https://github.com/openshift/cluster-capi-operator.git" "$tmp"
+
+echo "running cluster-capi-operator's: make e2e"
 exec make -C "$tmp" e2e


### PR DESCRIPTION
Fix e2e tests on release branches by running cluster-capi-operator tests off of the matching release branch.