### PR TITLE
OCPCLOUD-2680: Enable machine to node propagation

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -19,4 +19,5 @@ update-manifests-gen:
 .PHONY: ocp-manifests
 ocp-manifests: $(RELEASE_DIR) check-env ## Builds openshift specific manifests
 	# Generate provider manifests.
-	cd tools && $(MANIFESTS_GEN) --provider-name "cluster-api" --provider-type "CoreProvider" --provider-version "${PROVIDER_VERSION}" --base-path "../../" --manifests-path "../manifests"
+	# TODO: load the provider-version dynamically at rebase time when this is invoked by the Rebase Bot during one of its lifecycle hooks.
+	cd tools && $(MANIFESTS_GEN) --provider-name "cluster-api" --provider-type "CoreProvider" --provider-version "${PROVIDER_VERSION}" --base-path "../../" --manifests-path "../manifests" --kustomize-dir="openshift"

--- a/openshift/infrastructure-components-openshift.yaml
+++ b/openshift/infrastructure-components-openshift.yaml
@@ -14186,7 +14186,8 @@ spec:
         - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
         - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
         - --use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}
-        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},MachineWaitForVolumeDetachConsiderVolumeAttachments=${EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS:=true}
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}
+        - --additional-sync-machine-labels=.*
         command:
         - /manager
         env:

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../config/default
+
+patchesStrategicMerge:
+- ./patches/enable-metadata-syncing.yaml
+

--- a/openshift/manifests/0000_30_cluster-api_04_cm.core-cluster-api.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_cm.core-cluster-api.yaml
@@ -306,7 +306,8 @@ data:
             - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
             - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
             - --use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}
-            - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=true},MachineWaitForVolumeDetachConsiderVolumeAttachments=${EXP_MACHINE_WAITFORVOLUMEDETACH_CONSIDER_VOLUMEATTACHMENTS:=true}
+            - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}
+            - --additional-sync-machine-labels=.*
             command:
             - /manager
             env:

--- a/openshift/patches/enable-metadata-syncing.yaml
+++ b/openshift/patches/enable-metadata-syncing.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager # This patch is applied before manifests-gen renames it.
+  namespace: system        # This patch is applied before manifests-gen changes the namespace.
+spec:
+  template:
+    spec:
+     containers:
+     - name: manager
+       args:
+       - --leader-elect
+       - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
+       - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
+       - --use-deprecated-infra-machine-naming=${CAPI_USE_DEPRECATED_INFRA_MACHINE_NAMING:=false}
+       - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}
+       - --additional-sync-machine-labels=.*
+


### PR DESCRIPTION
This change contains two commits:

- **Enable label syncing from Machines to Nodes**. Maps to https://github.com/kubernetes-sigs/cluster-api/pull/11650 and https://issues.redhat.com/browse/OCPCLOUD-2680
- ~~**Enable annotation syncing from Machines to Nodes**. Maps to https://github.com/kubernetes-sigs/cluster-api/pull/11813 & https://issues.redhat.com/browse/OCPCLOUD-2860~~ this will be handled in a separate PR so as to unblock [OCPCLOUD-2680](https://issues.redhat.com//browse/OCPCLOUD-2680).


~~As of this writing, [OCPCLOUD-2680](https://issues.redhat.com//browse/OCPCLOUD-2680) is merged upstream, but is not yet in a released version. It should be in v1.9.5 when that is out.~~ We now have the necessary commit in our downstream fork.

~~If someone takes over this PR or has to split it up, you can get the same generated manifests with an updated version of CAPI with these commands (you'll need to include the updated `Makefile` and the two new kustomize files):~~


```
cd openshift
PROVIDER_VERSION=v1.9.4 make ocp-manifests
```