### PR TITLE
OCPCLOUD-3320: Fix continuous reconciliation of cluster-api manifests

### DIFF
--- a/config/rbac/aggregated_role.yaml
+++ b/config/rbac/aggregated_role.yaml
@@ -6,4 +6,3 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       cluster.x-k8s.io/aggregate-to-manager: "true"
-rules: []

--- a/controlplane/kubeadm/config/rbac/aggregated_role.yaml
+++ b/controlplane/kubeadm/config/rbac/aggregated_role.yaml
@@ -6,4 +6,3 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
-rules: []

--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -23912,7 +23912,6 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: cluster-api
   name: capi-aggregated-manager-role
-rules: []
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This is a backport of upstream https://github.com/kubernetes-sigs/cluster-api/pull/13490