### PR TITLE
NO-JIRA: IPAM CRDs: Use negated feature-gate: -ClusterAPIMachineManagement instead of feature-set: Default

### DIFF
--- a/openshift/ipam/kustomization.yaml
+++ b/openshift/ipam/kustomization.yaml
@@ -18,10 +18,9 @@ commonAnnotations:
   include.release.openshift.io/self-managed-high-availability: "true"
   include.release.openshift.io/single-node-developer: "true"
 
-  # Instructs CVO to only install these resources in clusters with the Default
-  # featureset. Specifically this means that they will not be installed in
-  # (TechPreview|Custom|Dev)NoUpgrade clusters.
-  release.openshift.io/feature-set: Default
+  # Instructs CVO to only install these resources when the ClusterAPIMachineManagement
+  # feature gate is NOT enabled.
+  release.openshift.io/feature-gate: -ClusterAPIMachineManagement
 
 resources:
 # Pinned at 4.20, as that was the last release which didn't have v1beta2

--- a/openshift/manifests/0000_30_cluster-api_04_crd.core-cluster-api.yaml
+++ b/openshift/manifests/0000_30_cluster-api_04_crd.core-cluster-api.yaml
@@ -6,7 +6,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: Default
+    release.openshift.io/feature-gate: -ClusterAPIMachineManagement
   name: ipaddressclaims.ipam.cluster.x-k8s.io
 spec:
   group: ipam.cluster.x-k8s.io
@@ -378,7 +378,7 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: Default
+    release.openshift.io/feature-gate: -ClusterAPIMachineManagement
   name: ipaddresses.ipam.cluster.x-k8s.io
 spec:
   group: ipam.cluster.x-k8s.io


### PR DESCRIPTION
Instead of using the Default feature-set, we want to use a negated feature-gate, as we want to deploy these resources only when the Feature Gate is off.

As such when the FeatureGate is on/on promotion they are deployed/managed by the CAPI Installer controller in cluster-capi-operator.