### PR TITLE
OCPBUGS-83760,OCPCLOUD-3419: Adopt IPAM CRDs on upgrade

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -23234,6 +23234,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    capi-operator.openshift.io/adopt-existing: always
     controller-gen.kubebuilder.io/version: v0.19.0
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
@@ -23590,6 +23591,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    capi-operator.openshift.io/adopt-existing: always
     controller-gen.kubebuilder.io/version: v0.19.0
     service.beta.openshift.io/inject-cabundle: "true"
   labels:

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -27,3 +27,15 @@ patches:
     version: v1
     kind: CustomResourceDefinition
     name: ipaddressclaims.ipam.cluster.x-k8s.io
+- path: ./patches/ipam-crd-adopt-existing.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: ipaddresses.ipam.cluster.x-k8s.io
+- path: ./patches/ipam-crd-adopt-existing.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: ipaddressclaims.ipam.cluster.x-k8s.io

--- a/openshift/patches/ipam-crd-adopt-existing.yaml
+++ b/openshift/patches/ipam-crd-adopt-existing.yaml
@@ -1,0 +1,13 @@
+# Add the adopt-existing annotation to IPAM CRDs.
+#
+# The IPAM CRDs were previously installed by CVO. When cluster-capi-operator
+# takes over management of these CRDs, it needs to adopt the existing resources.
+# This annotation instructs the operator to skip collision protection.
+#
+# Targets (specified in kustomization.yaml):
+#   - ipaddresses.ipam.cluster.x-k8s.io
+#   - ipaddressclaims.ipam.cluster.x-k8s.io
+
+- op: add
+  path: /metadata/annotations/capi-operator.openshift.io~1adopt-existing
+  value: "always"


### PR DESCRIPTION
Uses support added in https://github.com/openshift/cluster-capi-operator/pull/514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IPAM custom resource definition configuration to enable the CAPI operator to adopt and manage existing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->