### PR TITLE
OCPCLOUD-3359: Add TLS substitutions

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -24498,6 +24498,8 @@ spec:
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}
         - --additional-sync-machine-labels=.*
         - --additional-sync-machine-annotations=.*
+        - --tls-min-version=${TLS_MIN_VERSION}
+        - --tls-cipher-suites=${TLS_CIPHER_SUITES}
         command:
         - /manager
         env:

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -39,3 +39,15 @@ patches:
     version: v1
     kind: CustomResourceDefinition
     name: ipaddressclaims.ipam.cluster.x-k8s.io
+
+# Add TLS configuration args (substituted by cluster-capi-operator revisiongenerator)
+- target:
+    kind: Deployment
+    name: capi-controller-manager
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-min-version=${TLS_MIN_VERSION}"
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls-cipher-suites=${TLS_CIPHER_SUITES}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CAPI operator configuration to support customizable TLS settings via environment variables. Added TLS minimum version and cipher suites configuration options that can be customized during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->