### PR TITLE
CORS-4534: UPSTREAM: <carry>: Enable MachineTaintPropagation feature gate

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -24495,7 +24495,7 @@ spec:
         - --leader-elect
         - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
         - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
-        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}
+        - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false},MachineTaintPropagation=${EXP_MACHINE_TAINT_PROPAGATION:=true}
         - --additional-sync-machine-labels=.*
         - --additional-sync-machine-annotations=.*
         - --tls-min-version=${TLS_MIN_VERSION}

--- a/openshift/patches/enable-metadata-syncing.yaml
+++ b/openshift/patches/enable-metadata-syncing.yaml
@@ -12,7 +12,7 @@ spec:
        - --leader-elect
        - --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
        - --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}
-       - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false}
+       - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=true},ClusterTopology=${CLUSTER_TOPOLOGY:=false},RuntimeSDK=${EXP_RUNTIME_SDK:=false},MachineSetPreflightChecks=${EXP_MACHINE_SET_PREFLIGHT_CHECKS:=false},MachineTaintPropagation=${EXP_MACHINE_TAINT_PROPAGATION:=true}
        - --additional-sync-machine-labels=.*
        - --additional-sync-machine-annotations=.*
 


### PR DESCRIPTION
## Description

Enable `MachineTaintPropagation` feature gate on CAPI controllers. This is a requirement for edge compute pool (AWS local and wavelength zones).

See https://github.com/openshift/installer/pull/10625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Machine taint propagation is now included in the controller’s enabled feature set by default.
  * Other feature gate settings and defaults remain unchanged.
* **Configuration**
  * The default behavior can still be overridden using the existing environment-based configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->