### PR TITLE
OCPCLOUD-3434: add gh-summary target to download manifests from GitHub

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -1,4 +1,7 @@
 TOOLS_DIR := tools
+REPO_OWNER ?= openshift
+REPO_NAME ?= cluster-api-provider-aws
+PULL_BASE_SHA ?= main
 
 include provider-version.mk
 
@@ -12,12 +15,19 @@ $(TOOLS_DIR)/bin/%:
 	$(MAKE) -C $(TOOLS_DIR) bin/$*
 
 .PHONY: verify
-verify: verify-ocp-manifests
+verify: verify-ocp-manifests  verify-gh-summary
 
 .PHONY: verify-%
 verify-%: ## Ensure no diff after running some other target
 	$(MAKE) $*
 	./verify-diff.sh
+
+.PHONY: gh-summary
+gh-summary: gh-summary-default
+
+.PHONY: gh-summary-%
+gh-summary-%:
+	curl --connect-timeout 10 --max-time 120 --retry 3 -fsSL "https://raw.githubusercontent.com/$(REPO_OWNER)/$(REPO_NAME)/$(PULL_BASE_SHA)/openshift/capi-operator-manifests/$*/manifests-summary.yaml" -o "capi-operator-manifests/$*/manifests-summary.yaml"
 
 .PHONY: update-manifests-gen
 update-manifests-gen:


### PR DESCRIPTION
/hold

requires https://github.com/openshift/cluster-api/pull/305 to go first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manifest summary generation for CAPI resources, including RBAC, CRDs, deployments, services, and admission policies.
  * Added configurable repository and revision settings for retrieving GitHub manifest summaries.
  * Expanded verification to validate generated manifest summaries.

* **Maintenance**
  * Updated Go tooling and supporting Kubernetes/OpenShift dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->