### PR TITLE
OCPCLOUD-3434: fix REPO_NAME

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -1,6 +1,6 @@
 TOOLS_DIR := tools
 REPO_OWNER ?= openshift
-REPO_NAME ?= cluster-api-provider-aws
+REPO_NAME ?= cluster-api
 PULL_BASE_SHA ?= main
 
 include provider-version.mk


### PR DESCRIPTION
introduced in https://github.com/openshift/cluster-api/pull/306

